### PR TITLE
Don't clobber CRLF patches

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.0)
 project(pram
-	VERSION 9
+	VERSION 10
 	LANGUAGES NONE)
 
 # Silence the warning about not having a compiler -- we are not using

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('pram',
-  version: '9',
+  version: '10',
   license: 'BSD-2',
   meson_version: '>=0.49.0')
 

--- a/pram
+++ b/pram
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
-# (c) 2019 Michał Górny
+# (c) 2019-2021 Michał Górny
 # Released under the terms of the 2-clause BSD license
 
-VERSION=9
+VERSION=10
 
 die() {
 	echo "${@}" >&2

--- a/pram
+++ b/pram
@@ -238,7 +238,7 @@ main() {
 		if [[ -n ${pr} ]]; then
 			wget -O "${tempdir}/all.patch" "${pr}" || die "Fetching patch failed"
 		fi
-		git mailsplit -o"${tempdir}" "${tempdir}/all.patch" >/dev/null ||
+		git mailsplit --keep-cr -o"${tempdir}" "${tempdir}/all.patch" >/dev/null ||
 			die "Splitting patches failed"
 
 		local patches=( "${tempdir}"/[0-9]* )
@@ -301,7 +301,7 @@ main() {
 				esac
 			done
 		fi
-		git am -3 ${signoff:+-s} ${gpgsign:+-S} "${am_options[@]}" \
+		git am --keep-cr -3 ${signoff:+-s} ${gpgsign:+-S} "${am_options[@]}" \
 			"${tempdir}/all.patch" || die "git am failed"
 	done
 }

--- a/test/00basic.sh
+++ b/test/00basic.sh
@@ -38,7 +38,7 @@ cat > trivial.patch <<-EOF
 	--- /dev/null
 	+++ b/newfile.txt
 	@@ -0,0 +1 @@
-	+Also, a new file.
+	+Also, a new file with CRLF line ending.
 	--
 	2.21.0
 EOF
@@ -55,5 +55,5 @@ diff -u - git-log.txt <<-EOF
 EOF
 sha1sum -c <<EOF
 8054584c7b1fa9b5bdd7ee1177e78c99ea2cce04  data.txt
-810ded956f70861874e2c6083c5dc9e9e80f1808  newfile.txt
+f83370dac2432114808711e29f399f9b0c87fc23  newfile.txt
 EOF


### PR DESCRIPTION
* `--keep-cr` is required for preventing git am/mailsplit
  from breaking CRLF patches in FILESDIR.