### PR TITLE
Add `Part-of:` trailer to patches

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -28,6 +28,8 @@ tests = [
   '06gpgsign',
   '10threeway',
   '10threeway-disabled',
+  '11combined-partof-signoff-bug',
+  '11partof',
 ]
 
 foreach t : tests

--- a/meson.build
+++ b/meson.build
@@ -12,6 +12,7 @@ sh = find_program('sh')
 tests = [
   '00basic',
   '01signoff-missing',
+  '01signoff-partial',
   '01signoff-present',
   '02bug-number',
   '02bug-url',

--- a/pram
+++ b/pram
@@ -37,6 +37,9 @@ print_help() {
 	echo "  -s, --signoff    Add Signed-off-by to commits (the default)"
 	echo "  -S, --no-signoff Disable adding Signed-off-by to commits"
 	echo "  -p, --part-of    Add Part-of to commits, linking to the PR (the default)"
+	echo "  --part-of-pr PULL_REQUEST"
+	echo "                   Override the pull request to link with -p/--part-of."
+	echo "                   Implies -p"
 	echo "  -P, --no-part-of Disable adding Part-of to commits"
 	echo
 	echo "Parameters:"
@@ -46,7 +49,7 @@ print_help() {
 	echo
 	echo "Some options can be specified via 'git config' as well:"
 	echo "  string options: pram.editor, pram.repo"
-	echo "  boolean options: pram.gpgsign, pram.interactive, pram.signoff"
+	echo "  boolean options: pram.gpgsign, pram.interactive, pram.signoff, pram.partof"
 }
 
 # add_trailer <file> <line-to-add>
@@ -73,6 +76,7 @@ main() {
 	local gitconfig=1
 	local gpgsign=def
 	local partof=def
+	local user_pr=
 
 	while [[ ${#} -gt 0 ]]; do
 		case ${1} in
@@ -155,6 +159,18 @@ main() {
 			-p|--part-of)
 				partof=1
 				;;
+			--part-of-pr)
+				partof=1
+				[[ -z ${user_pr} ]] || die "${0}: cannot specify multiple ${1}"
+				[[ ${#} -gt 1 ]] || die "${0}: missing argument to ${1}"
+				user_pr=${2}
+				shift
+				;;
+			--part-of-pr=*)
+				partof=1
+				[[ -z ${user_pr} ]] || die "${0}: cannot specify multiple ${1%%=*}"
+				user_pr=${1#*=}
+				;;
 			-P|--no-part-of)
 				partof=
 				;;
@@ -217,12 +233,13 @@ main() {
 	tempdir=$(mktemp -d) || die "Unable to create a temporary directory"
 	trap 'rm -r -f "${tempdir}"' EXIT
 
-	local pr to_close
+	local pr to_close linked_pr
 	for pr in "${prs[@]}"; do
 		case ${pr} in
 			*://github.com/*/*/pull/*)
 				# GitHub URL
 				to_close=${pr%.patch}
+				linked_pr=${to_close}
 				pr=${to_close}.patch
 				;;
 			*://*.bugs.gentoo.org/attachment.cgi?*)
@@ -230,18 +247,22 @@ main() {
 				# (get bug no from domain name)
 				to_close=${pr%%.bugs*}
 				to_close="https://bugs.gentoo.org/${to_close#*://}"
+				linked_pr=${to_close}
 				;;
 			*://*)
 				# arbitrary URL
 				to_close=
+				linked_pr=${pr}
 				;;
 			[0-9]*)
 				# a number?
 				to_close="https://github.com/${repo}/pull/${pr}"
+				linked_pr=${to_close}
 				pr=${to_close}.patch
 				;;
 			*)
 				# a local file maybe?
+				[[ ! ${partof} || -n ${user_pr} ]] || die "--part-of-pr is mandatory with local files with --part-of"
 				to_close=
 				[[ -f ${pr} ]] ||
 					die "Parameter neither an URL, number or file: ${pr}"
@@ -254,9 +275,24 @@ main() {
 		fi
 		git mailsplit --keep-cr -o"${tempdir}" "${tempdir}/all.patch" >/dev/null ||
 			die "Splitting patches failed"
+		
+		if [[ ${partof} && -n ${user_pr} ]]; then
+			case ${user_pr} in
+				*://*)
+					# already fine
+					linked_pr=${user_pr}
+					;;
+				[0-9]*)
+					linked_pr="https://github.com/${repo}/pull/${user_pr}"
+					;;
+				*)
+					die "Unknown format for linked pull request: ${user_pr}"
+					;;
+			esac
+		fi
 
 		local patches=( "${tempdir}"/[0-9]* )
-		if [[ ${signoff} ]] || [[ ${partof} ]]; then
+		if [[ ${signoff} || ${partof} ]]; then
 			local f
 			for f in "${patches[@]}"; do
 				if [[ ${signoff} ]]; then
@@ -266,7 +302,7 @@ main() {
 				fi
 
 				if [[ ${partof} ]]; then
-					add_trailer "${f}" "Part-of: ${to_close}"
+					add_trailer "${f}" "Part-of: ${linked_pr}"
 				fi
 			done
 		fi

--- a/pram
+++ b/pram
@@ -36,6 +36,8 @@ print_help() {
 	echo "                   GitHub repo to use (default: gentoo/gentoo)"
 	echo "  -s, --signoff    Add Signed-off-by to commits (the default)"
 	echo "  -S, --no-signoff Disable adding Signed-off-by to commits"
+	echo "  -p, --part-of    Add Part-of to commits, linking to the PR (the default)"
+	echo "  -P, --no-part-of Disable adding Part-of to commits"
 	echo
 	echo "Parameters:"
 	echo "  <pr-number>      GitHub PR number"
@@ -70,6 +72,7 @@ main() {
 	local interactive=def
 	local gitconfig=1
 	local gpgsign=def
+	local partof=def
 
 	while [[ ${#} -gt 0 ]]; do
 		case ${1} in
@@ -149,6 +152,12 @@ main() {
 			-S|--no-signoff)
 				signoff=
 				;;
+			-p|--part-of)
+				partof=1
+				;;
+			-P|--no-part-of)
+				partof=
+				;;
 			-*)
 				print_usage >&2
 				exit 1
@@ -193,6 +202,11 @@ main() {
 			opt=$(git config --type bool --get pram.gpgsign)
 			[[ ${opt} == true ]] && gpgsign=1
 			[[ ${opt} == false ]] && gpgsign=
+		fi
+		if [[ ${partof} == def ]]; then
+			opt=$(git config --type bool --get pram.partof)
+			[[ ${opt} == true ]] && partof=1
+			[[ ${opt} == false ]] && partof=
 		fi
 	fi
 
@@ -242,11 +256,17 @@ main() {
 			die "Splitting patches failed"
 
 		local patches=( "${tempdir}"/[0-9]* )
-		if [[ ${signoff} ]]; then
+		if [[ ${signoff} ]] || [[ ${partof} ]]; then
 			local f
-			for f in "${patches}"; do
-				if ! grep -q '^Signed-off-by:' "${f}"; then
-					die "Commit no. ${f##*/} was not signed off by the author!"
+			for f in "${patches[@]}"; do
+				if [[ ${signoff} ]]; then
+					if ! grep -q '^Signed-off-by:' "${f}"; then
+						die "Commit no. ${f##*/} was not signed off by the author!"
+					fi
+				fi
+
+				if [[ ${partof} ]]; then
+					add_trailer "${f}" "Part-of: ${to_close}"
 				fi
 			done
 		fi

--- a/pram.1
+++ b/pram.1
@@ -39,6 +39,11 @@ Add Signed-off-by to commits (the default)
 .TP
 \fB-S\fR, \fB\-\-no\-signoff\fR
 Disable adding Signed-off-by to commits
+\fB\-p\fR, \fB\-\-part-of\fR
+Add Part-of to commits, linking to the PR (the default)
+.TP
+\fB-P\fR, \fB\-\-no\-part-of\fR
+Disable adding Part-of to commits
 
 .SH PARAMETERS
 .IP \fI<pr-number>\fP
@@ -57,10 +62,10 @@ files.
 The following options are currently supported:
 .TP
 string options:
-\fIpram.editor\fR, \fIpram.repository\fR
+\fIpram.editor\fR, \fIpram.repo\fR
 .TP
 boolean options (\fB--type bool\fR):
-\fIpram.gpgsign\fR, \fIpram.interactive\fR, \fIpram.signoff\fR
+\fIpram.gpgsign\fR, \fIpram.interactive\fR, \fIpram.signoff\fR, \fIpram.partof\fR
 
 .SH LICENSE
 This program is free software; you can redistribute it and/or modify

--- a/pram.1
+++ b/pram.1
@@ -39,11 +39,15 @@ Add Signed-off-by to commits (the default)
 .TP
 \fB-S\fR, \fB\-\-no\-signoff\fR
 Disable adding Signed-off-by to commits
+.TP
 \fB\-p\fR, \fB\-\-part-of\fR
 Add Part-of to commits, linking to the PR (the default)
 .TP
 \fB-P\fR, \fB\-\-no\-part-of\fR
 Disable adding Part-of to commits
+.TP
+\fB\-\-part-of-pr \fIPULL_REQUEST\fR
+Override the pull request to link with -p/--part-of. Implies -p
 
 .SH PARAMETERS
 .IP \fI<pr-number>\fP

--- a/test/00basic.sh
+++ b/test/00basic.sh
@@ -43,7 +43,7 @@ cat > trivial.patch <<-EOF
 	2.21.0
 EOF
 
-bash "${INITDIR}"/../pram --no-gitconfig -e true -G -I -S ./trivial.patch
+bash "${INITDIR}"/../pram --no-gitconfig -e true -G -I -S -P ./trivial.patch
 
 git log --format='%ae%n%an%n%aI%n%B' -1 > git-log.txt
 diff -u - git-log.txt <<-EOF

--- a/test/01signoff-missing.sh
+++ b/test/01signoff-missing.sh
@@ -43,7 +43,7 @@ cat > trivial.patch <<-EOF
 	2.21.0
 EOF
 
-! bash "${INITDIR}"/../pram --no-gitconfig -e true -G -I -s ./trivial.patch 2> out.txt
+! bash "${INITDIR}"/../pram --no-gitconfig -e true -G -I -s -P ./trivial.patch 2> out.txt
 
 diff -u - out.txt <<-EOF
 	Commit no. 0001 was not signed off by the author!

--- a/test/01signoff-partial.sh
+++ b/test/01signoff-partial.sh
@@ -1,0 +1,91 @@
+#!/bin/sh
+# Test whether a set of commits where only one is missing causes rejection.
+
+set -e -x
+
+. ./common-setup.sh
+
+cat > three-commits.patch <<-EOF
+	From 243f5779c2ae9b0d117829b60fe7dbc466e968c0 Mon Sep 17 00:00:00 2001
+	From: Other person <other@example.com>
+	Date: Sat, 1 Jan 2000 00:00:00 +0000
+	Subject: [PATCH 1/3] First patch
+
+	Signed-off-by: Other person <other@example.com>
+
+	---
+	 data.txt | 2 +-
+	 1 file changed, 1 insertion(+), 1 deletion(-)
+
+	diff --git a/data.txt b/data.txt
+	index 5baade6..a9a301d 100644
+	--- a/data.txt
+	+++ b/data.txt
+	@@ -1,6 +1,6 @@
+	 This is some initial data.
+
+	-001100
+	+001101
+	 010010
+	 011110
+	 100001
+	--
+	2.49.0
+
+	From 7aab19414dd17546985fd7c0091e779944e8f0df Mon Sep 17 00:00:00 2001
+	From: Other person <other@example.com>
+	Date: Sat, 1 Jan 2000 00:00:00 +0000
+	Subject: [PATCH 2/3] Second patch
+
+	---
+	 data.txt | 2 +-
+	 1 file changed, 1 insertion(+), 1 deletion(-)
+
+	diff --git a/data.txt b/data.txt
+	index a9a301d..237b5ef 100644
+	--- a/data.txt
+	+++ b/data.txt
+	@@ -1,7 +1,7 @@
+	 This is some initial data.
+
+	 001101
+	-010010
+	+010011
+	 011110
+	 100001
+	 101101
+	--
+	2.49.0
+
+	From 8be43d8aa258fd2c2cf25ec540d19ab6a25d4038 Mon Sep 17 00:00:00 2001
+	From: Other person <other@example.com>
+	Date: Sat, 1 Jan 2000 00:00:00 +0000
+	Subject: [PATCH 3/3] Third patch
+
+	Signed-off-by: Other person <other@example.com>
+
+	---
+	 data.txt | 2 +-
+	 1 file changed, 1 insertion(+), 1 deletion(-)
+
+	diff --git a/data.txt b/data.txt
+	index 237b5ef..6ba7c31 100644
+	--- a/data.txt
+	+++ b/data.txt
+	@@ -3,6 +3,6 @@ This is some initial data.
+	 001101
+	 010011
+	 011110
+	-100001
+	+101101
+	 101101
+	 110011
+	--
+	2.49.0
+EOF
+
+! bash "${INITDIR}"/../pram --no-gitconfig -e true -G -I -s -P ./three-commits.patch 2> out.txt
+
+diff -u - out.txt <<-EOF
+	Commit no. 0002 was not signed off by the author!
+EOF

--- a/test/01signoff-present.sh
+++ b/test/01signoff-present.sh
@@ -45,7 +45,7 @@ cat > trivial.patch <<-EOF
 	2.21.0
 EOF
 
-bash "${INITDIR}"/../pram --no-gitconfig -e true -G -I -s ./trivial.patch
+bash "${INITDIR}"/../pram --no-gitconfig -e true -G -I -s -P ./trivial.patch
 
 git log --format='%ae%n%an%n%ce%n%cn%n%aI%n%B' -1 > git-log.txt
 diff -u - git-log.txt <<-EOF

--- a/test/02bug-number.sh
+++ b/test/02bug-number.sh
@@ -43,7 +43,7 @@ cat > trivial.patch <<-EOF
 	2.21.0
 EOF
 
-bash "${INITDIR}"/../pram --no-gitconfig -e true -G -I -S -b 314152 ./trivial.patch
+bash "${INITDIR}"/../pram --no-gitconfig -e true -G -I -S -b 314152 -P ./trivial.patch
 
 git log --format='%ae%n%an%n%aI%n%B' -1 > git-log.txt
 diff -u - git-log.txt <<-EOF

--- a/test/02bug-url.sh
+++ b/test/02bug-url.sh
@@ -43,7 +43,7 @@ cat > trivial.patch <<-EOF
 	2.21.0
 EOF
 
-bash "${INITDIR}"/../pram --no-gitconfig -e true -G -I -S -b https://bugs.example.com/123456 ./trivial.patch
+bash "${INITDIR}"/../pram --no-gitconfig -e true -G -I -S -b https://bugs.example.com/123456 -P ./trivial.patch
 
 git log --format='%ae%n%an%n%aI%n%B' -1 > git-log.txt
 diff -u - git-log.txt <<-EOF

--- a/test/02closes-number.sh
+++ b/test/02closes-number.sh
@@ -43,7 +43,7 @@ cat > trivial.patch <<-EOF
 	2.21.0
 EOF
 
-bash "${INITDIR}"/../pram --no-gitconfig -e true -G -I -S -c 314152 ./trivial.patch
+bash "${INITDIR}"/../pram --no-gitconfig -e true -G -I -S -c 314152 -P ./trivial.patch
 
 git log --format='%ae%n%an%n%aI%n%B' -1 > git-log.txt
 diff -u - git-log.txt <<-EOF

--- a/test/02closes-url.sh
+++ b/test/02closes-url.sh
@@ -43,7 +43,7 @@ cat > trivial.patch <<-EOF
 	2.21.0
 EOF
 
-bash "${INITDIR}"/../pram --no-gitconfig -e true -G -I -S -c https://bugs.example.com/123456 ./trivial.patch
+bash "${INITDIR}"/../pram --no-gitconfig -e true -G -I -S -c https://bugs.example.com/123456 -P ./trivial.patch
 
 git log --format='%ae%n%an%n%aI%n%B' -1 > git-log.txt
 diff -u - git-log.txt <<-EOF

--- a/test/03bug-multiple.sh
+++ b/test/03bug-multiple.sh
@@ -43,7 +43,7 @@ cat > trivial.patch <<-EOF
 	2.21.0
 EOF
 
-bash "${INITDIR}"/../pram --no-gitconfig -e true -G -I -S -b 314152 -b 314156 -b 314154 ./trivial.patch
+bash "${INITDIR}"/../pram --no-gitconfig -e true -G -I -S -b 314152 -b 314156 -b 314154 -P ./trivial.patch
 
 git log --format='%ae%n%an%n%aI%n%B' -1 > git-log.txt
 diff -u - git-log.txt <<-EOF

--- a/test/03closes-multiple.sh
+++ b/test/03closes-multiple.sh
@@ -43,7 +43,7 @@ cat > trivial.patch <<-EOF
 	2.21.0
 EOF
 
-bash "${INITDIR}"/../pram --no-gitconfig -e true -G -I -S -c 314152 -c 314156 -c 314154 ./trivial.patch
+bash "${INITDIR}"/../pram --no-gitconfig -e true -G -I -S -c 314152 -c 314156 -c 314154 -P ./trivial.patch
 
 git log --format='%ae%n%an%n%aI%n%B' -1 > git-log.txt
 diff -u - git-log.txt <<-EOF

--- a/test/03combined-bug-closes.sh
+++ b/test/03combined-bug-closes.sh
@@ -43,7 +43,7 @@ cat > trivial.patch <<-EOF
 	2.21.0
 EOF
 
-bash "${INITDIR}"/../pram --no-gitconfig -e true -G -I -S -c 314152 -b 314156 -b 314154 ./trivial.patch
+bash "${INITDIR}"/../pram --no-gitconfig -e true -G -I -S -c 314152 -b 314156 -b 314154 -P ./trivial.patch
 
 git log --format='%ae%n%an%n%aI%n%B' -1 > git-log.txt
 diff -u - git-log.txt <<-EOF

--- a/test/03combined-signoff-bug.sh
+++ b/test/03combined-signoff-bug.sh
@@ -44,7 +44,7 @@ cat > trivial.patch <<-EOF
 	2.21.0
 EOF
 
-bash "${INITDIR}"/../pram --no-gitconfig -e true -G -I -s -b 314152 -c 314154 ./trivial.patch
+bash "${INITDIR}"/../pram --no-gitconfig -e true -G -I -s -b 314152 -c 314154 -P ./trivial.patch
 
 git log --format='%ae%n%an%n%ce%n%cn%n%aI%n%B' -1 > git-log.txt
 diff -u - git-log.txt <<-EOF

--- a/test/04interactive-no.sh
+++ b/test/04interactive-no.sh
@@ -44,6 +44,6 @@ cat > trivial.patch <<-EOF
 EOF
 
 BEFORE=$(git rev-parse HEAD)
-echo 'n' | bash "${INITDIR}"/../pram --no-gitconfig -e true -G -S ./trivial.patch
+echo 'n' | bash "${INITDIR}"/../pram --no-gitconfig -e true -G -S -P ./trivial.patch
 
 [ "${BEFORE}" = "$(git rev-parse HEAD)" ]

--- a/test/04interactive-yes.sh
+++ b/test/04interactive-yes.sh
@@ -43,7 +43,7 @@ cat > trivial.patch <<-EOF
 	2.21.0
 EOF
 
-echo 'y' | bash "${INITDIR}"/../pram --no-gitconfig -e true -G -S ./trivial.patch
+echo 'y' | bash "${INITDIR}"/../pram --no-gitconfig -e true -G -S -P ./trivial.patch
 
 git log --format='%ae%n%an%n%aI%n%B' -1 > git-log.txt
 diff -u - git-log.txt <<-EOF

--- a/test/05editor-empty.sh
+++ b/test/05editor-empty.sh
@@ -44,6 +44,6 @@ cat > trivial.patch <<-EOF
 EOF
 
 BEFORE=$(git rev-parse HEAD)
-bash "${INITDIR}"/../pram --no-gitconfig -e 'truncate -s 0' -G -I -S ./trivial.patch
+bash "${INITDIR}"/../pram --no-gitconfig -e 'truncate -s 0' -G -I -S -P ./trivial.patch
 
 [ "${BEFORE}" = "$(git rev-parse HEAD)" ]

--- a/test/05editor-fail.sh
+++ b/test/05editor-fail.sh
@@ -44,6 +44,6 @@ cat > trivial.patch <<-EOF
 EOF
 
 BEFORE=$(git rev-parse HEAD)
-! bash "${INITDIR}"/../pram --no-gitconfig -e false -G -I -S ./trivial.patch
+! bash "${INITDIR}"/../pram --no-gitconfig -e false -G -I -S -P ./trivial.patch
 
 [ "${BEFORE}" = "$(git rev-parse HEAD)" ]

--- a/test/06gpgsign.sh
+++ b/test/06gpgsign.sh
@@ -49,7 +49,7 @@ cat > trivial.patch <<-EOF
 	2.21.0
 EOF
 
-bash "${INITDIR}"/../pram --no-gitconfig -e true -I -S ./trivial.patch
+bash "${INITDIR}"/../pram --no-gitconfig -e true -I -S -P ./trivial.patch
 
 git log --format='%ae%n%an%n%aI%n%G?%n%B' -1 > git-log.txt
 diff -u - git-log.txt <<-EOF

--- a/test/10threeway-disabled.sh
+++ b/test/10threeway-disabled.sh
@@ -48,6 +48,6 @@ cat > trivial.patch <<-EOF
 EOF
 
 BEFORE=$(git rev-parse HEAD)
-! bash "${INITDIR}"/../pram --no-gitconfig -e true -G -I -S --am-options '--no-3way' ./trivial.patch
+! bash "${INITDIR}"/../pram --no-gitconfig -e true -G -I -S --am-options '--no-3way' -P ./trivial.patch
 
 [ "${BEFORE}" = "$(git rev-parse HEAD)" ]

--- a/test/10threeway.sh
+++ b/test/10threeway.sh
@@ -47,7 +47,7 @@ cat > trivial.patch <<-EOF
 	2.21.0
 EOF
 
-bash "${INITDIR}"/../pram --no-gitconfig -e true -G -I -S ./trivial.patch
+bash "${INITDIR}"/../pram --no-gitconfig -e true -G -I -S -P ./trivial.patch
 
 git log --format='%ae%n%an%n%aI%n%B' -1 > git-log.txt
 diff -u - git-log.txt <<-EOF

--- a/test/11combined-partof-signoff-bug.sh
+++ b/test/11combined-partof-signoff-bug.sh
@@ -1,0 +1,69 @@
+#!/bin/sh
+# Test whether Part-of is properly combined with signoff and bug/closes tags.
+# Minor variation on 03combined-signoff-bug.
+
+set -e -x
+
+. ./common-setup.sh
+
+cat > trivial.patch <<-EOF
+	From 88460bc61f56546da478dc6fd4682e7c62cc6c80 Mon Sep 17 00:00:00 2001
+	From: Other person <other@example.com>
+	Date: Sat, 1 Jan 2000 00:00:00 +0000
+	Subject: [PATCH] A trivial patch
+
+	Signed-off-by: Other person <other@example.com>
+	---
+	 data.txt    | 4 ++--
+	 newfile.txt | 1 +
+	 2 files changed, 3 insertions(+), 2 deletions(-)
+	 create mode 100644 newfile.txt
+
+	diff --git a/data.txt b/data.txt
+	index 5baade6..0139962 100644
+	--- a/data.txt
+	+++ b/data.txt
+	@@ -1,8 +1,8 @@
+	 This is some initial data.
+
+	 001100
+	-010010
+	-011110
+	 100001
+	+011110
+	+010010
+	 101101
+	 110011
+	diff --git a/newfile.txt b/newfile.txt
+	new file mode 100644
+	index 0000000..6d8bf33
+	--- /dev/null
+	+++ b/newfile.txt
+	@@ -0,0 +1 @@
+	+Also, a new file.
+	--
+	2.21.0
+EOF
+
+bash "${INITDIR}"/../pram --no-gitconfig -e true -G -I -s -b 314152 -c 314154 --part-of-pr 123 ./trivial.patch
+
+git log --format='%ae%n%an%n%ce%n%cn%n%aI%n%B' -1 > git-log.txt
+diff -u - git-log.txt <<-EOF
+	other@example.com
+	Other person
+	pram@example.com
+	PRam test
+	2000-01-01T00:00:00Z
+	A trivial patch
+
+	Signed-off-by: Other person <other@example.com>
+	Part-of: https://github.com/gentoo/gentoo/pull/123
+	Bug: https://bugs.gentoo.org/314152
+	Closes: https://bugs.gentoo.org/314154
+	Signed-off-by: PRam test <pram@example.com>
+
+EOF
+sha1sum -c <<EOF
+8054584c7b1fa9b5bdd7ee1177e78c99ea2cce04  data.txt
+810ded956f70861874e2c6083c5dc9e9e80f1808  newfile.txt
+EOF

--- a/test/11partof.sh
+++ b/test/11partof.sh
@@ -1,0 +1,112 @@
+#!/bin/sh
+# Test whether the Part-of trailer is correctly added to every commit.
+
+set -e -x
+
+. ./common-setup.sh
+
+cat > three-commits.patch <<-EOF
+	From 243f5779c2ae9b0d117829b60fe7dbc466e968c0 Mon Sep 17 00:00:00 2001
+	From: PRam test <pram@example.com>
+	Date: Sat, 1 Jan 2000 00:00:00 +0000
+	Subject: [PATCH 1/3] First patch
+
+	---
+	 data.txt | 2 +-
+	 1 file changed, 1 insertion(+), 1 deletion(-)
+
+	diff --git a/data.txt b/data.txt
+	index 5baade6..a9a301d 100644
+	--- a/data.txt
+	+++ b/data.txt
+	@@ -1,6 +1,6 @@
+	 This is some initial data.
+
+	-001100
+	+001101
+	 010010
+	 011110
+	 100001
+	--
+	2.49.0
+
+	From 7aab19414dd17546985fd7c0091e779944e8f0df Mon Sep 17 00:00:00 2001
+	From: PRam test <pram@example.com>
+	Date: Sat, 1 Jan 2000 00:00:00 +0000
+	Subject: [PATCH 2/3] Second patch
+
+	---
+	 data.txt | 2 +-
+	 1 file changed, 1 insertion(+), 1 deletion(-)
+
+	diff --git a/data.txt b/data.txt
+	index a9a301d..237b5ef 100644
+	--- a/data.txt
+	+++ b/data.txt
+	@@ -1,7 +1,7 @@
+	 This is some initial data.
+
+	 001101
+	-010010
+	+010011
+	 011110
+	 100001
+	 101101
+	--
+	2.49.0
+
+	From 8be43d8aa258fd2c2cf25ec540d19ab6a25d4038 Mon Sep 17 00:00:00 2001
+	From: PRam test <pram@example.com>
+	Date: Sat, 1 Jan 2000 00:00:00 +0000
+	Subject: [PATCH 3/3] Third patch
+
+	---
+	 data.txt | 2 +-
+	 1 file changed, 1 insertion(+), 1 deletion(-)
+
+	diff --git a/data.txt b/data.txt
+	index 237b5ef..6ba7c31 100644
+	--- a/data.txt
+	+++ b/data.txt
+	@@ -3,6 +3,6 @@ This is some initial data.
+	 001101
+	 010011
+	 011110
+	-100001
+	+101101
+	 101101
+	 110011
+	--
+	2.49.0
+EOF
+
+# Test without signoff so we're only testing one thing
+bash "${INITDIR}"/../pram --no-gitconfig -e true -G -I -S --part-of-pr 123 ./three-commits.patch
+
+git log --format='%ae%n%an%n%aI%n%B' -3 > git-log.txt
+diff -u - git-log.txt <<-EOF
+	pram@example.com
+	PRam test
+	2000-01-01T00:00:00Z
+	Third patch
+
+	Part-of: https://github.com/gentoo/gentoo/pull/123
+
+	pram@example.com
+	PRam test
+	2000-01-01T00:00:00Z
+	Second patch
+
+	Part-of: https://github.com/gentoo/gentoo/pull/123
+
+	pram@example.com
+	PRam test
+	2000-01-01T00:00:00Z
+	First patch
+
+	Part-of: https://github.com/gentoo/gentoo/pull/123
+
+EOF
+sha256sum -c <<-EOF
+	c95bc3022ee967e117fc7841d9b6597e672d7ef1da7897b2c2692fe8b099911d  data.txt
+EOF


### PR DESCRIPTION
I went with `Part-of:` because it feels the most broadly correct (across forges).

To achieve this, I refactored the loop where it checks signoffs to also optionally (but by default) add `Part-of:` trailers.

I think this also fixes a bug where the patches weren't looped through correctly, so only the first commit was checked for signoffs.

This also fixes a minor documentation issue, where the git config key for `pram.repo` was listed as `pram.repository`.

(Truthfully, this was initially just to fix that documentation issue, but then I saw an open issue I could tackle while I was at it :)