### PR TITLE
Add `Part-of` trailer and `--link-to` flag

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -29,6 +29,8 @@ tests = [
   '06gpgsign',
   '10threeway',
   '10threeway-disabled',
+  '11combined-partof-signoff-bug',
+  '11partof',
 ]
 
 foreach t : tests

--- a/meson.build
+++ b/meson.build
@@ -12,6 +12,7 @@ sh = find_program('sh')
 tests = [
   '00basic',
   '01signoff-missing',
+  '01signoff-partial',
   '01signoff-present',
   '02bug-number',
   '02bug-url',

--- a/pram
+++ b/pram
@@ -261,13 +261,14 @@ main() {
 			;;
 		*)
 			# a local file maybe?
-			if [[ ${partof} == def && -z ${link_to} ]]; then
+			if [[ -z ${link_to} ]]; then
 				# only add partof for local files if explicitly asked for
-				partof=
+				if [[ ${partof} == def ]]; then
+					partof=
+				elif [[ ${partof} ]]; then
+					die "specifying --link-to is mandatory with local files when using --part-of"
+				fi
 			fi
-			[[ ! ${partof} || -n ${link_to} ]] ||
-				die "specifying --link-to is mandatory with local files when using --part-of"
-
 			to_close=
 			[[ -f ${pr} ]] ||
 				die "Parameter neither an URL, number or file: ${pr}"

--- a/pram
+++ b/pram
@@ -36,6 +36,12 @@ print_help() {
 	echo "                   GitHub repo to use (default: gentoo/gentoo)"
 	echo "  -s, --signoff    Add Signed-off-by to commits (the default)"
 	echo "  -S, --no-signoff Disable adding Signed-off-by to commits"
+	echo "  -p, --part-of    Add Part-of to commits, linking to the PR (the default)"
+	echo "  -P, --no-part-of Disable adding Part-of to commits"
+	echo "  --link-to PULL_REQUEST"
+	echo "                   Override the pull request the merge is linked to. This"
+	echo "                   will override the Part-of trailer, as well as the final"
+	echo "                   Closes trailer."
 	echo
 	echo "Parameters:"
 	echo "  <pr-number>      GitHub PR number"
@@ -44,7 +50,7 @@ print_help() {
 	echo
 	echo "Some options can be specified via 'git config' as well:"
 	echo "  string options: pram.editor, pram.repo"
-	echo "  boolean options: pram.gpgsign, pram.interactive, pram.signoff"
+	echo "  boolean options: pram.gpgsign, pram.interactive, pram.signoff, pram.partof"
 }
 
 # add_trailer <file> <line-to-add>
@@ -70,6 +76,8 @@ main() {
 	local interactive=def
 	local gitconfig=1
 	local gpgsign=def
+	local partof=def
+	local link_to=
 
 	while [[ ${#} -gt 0 ]]; do
 		case ${1} in
@@ -149,6 +157,22 @@ main() {
 			-S|--no-signoff)
 				signoff=
 				;;
+			-p|--part-of)
+				partof=1
+				;;
+			-P|--no-part-of)
+				partof=
+				;;
+			--link-to)
+				[[ -z ${link_to} ]] || die "${0}: cannot specify multiple ${1}"
+				[[ ${#} -gt 1 ]] || die "${0}: missing argument to ${1}"
+				link_to=${2}
+				shift
+				;;
+			--link-to=*)
+				[[ -z ${link_to} ]] || die "${0}: cannot specify multiple ${1%%=*}"
+				link_to=${1#*=}
+				;;
 			-*)
 				print_usage >&2
 				exit 1
@@ -199,6 +223,11 @@ main() {
 			[[ ${opt} == true ]] && gpgsign=1
 			[[ ${opt} == false ]] && gpgsign=
 		fi
+		if [[ ${partof} == def ]]; then
+			opt=$(git config --type bool --get pram.partof)
+			[[ ${opt} == true ]] && partof=1
+			[[ ${opt} == false ]] && partof=
+		fi
 	fi
 
 	# set defaults
@@ -232,6 +261,8 @@ main() {
 			;;
 		*)
 			# a local file maybe?
+			[[ ! ${partof} || -n ${link_to} ]] || 
+				die "specifying --link-to is mandatory with local files when using --part-of"
 			to_close=
 			[[ -f ${pr} ]] ||
 				die "Parameter neither an URL, number or file: ${pr}"
@@ -245,12 +276,34 @@ main() {
 	git mailsplit --keep-cr -o"${tempdir}" "${tempdir}/all.patch" >/dev/null ||
 		die "Splitting patches failed"
 
+	if [[ ${partof} && -n ${link_to} ]]; then
+		case ${link_to} in
+			*://*)
+				# already fine
+				to_close=${link_to}
+				;;
+			[0-9]*)
+				to_close="https://github.com/${repo}/pull/${link_to}"
+				;;
+			*)
+				die "Unknown format for linked pull request: ${link_to}"
+				;;
+		esac
+
+	fi
+
 	local patches=( "${tempdir}"/[0-9]* )
-	if [[ ${signoff} ]]; then
+	if [[ ${signoff} || ${partof} ]]; then
 		local f
 		for f in "${patches[@]}"; do
-			if ! grep -q '^Signed-off-by:' "${f}"; then
-				die "Commit no. ${f##*/} was not signed off by the author!"
+			if [[ ${signoff} ]]; then
+				if ! grep -q '^Signed-off-by:' "${f}"; then
+					die "Commit no. ${f##*/} was not signed off by the author!"
+				fi
+			fi
+
+			if [[ ${partof} ]]; then
+				add_trailer "${f}" "Part-of: ${to_close}"
 			fi
 		done
 	fi

--- a/pram
+++ b/pram
@@ -248,7 +248,7 @@ main() {
 	local patches=( "${tempdir}"/[0-9]* )
 	if [[ ${signoff} ]]; then
 		local f
-		for f in "${patches}"; do
+		for f in "${patches[@]}"; do
 			if ! grep -q '^Signed-off-by:' "${f}"; then
 				die "Commit no. ${f##*/} was not signed off by the author!"
 			fi

--- a/pram
+++ b/pram
@@ -261,8 +261,13 @@ main() {
 			;;
 		*)
 			# a local file maybe?
-			[[ ! ${partof} || -n ${link_to} ]] || 
+			if [[ ${partof} == def && -z ${link_to} ]]; then
+				# only add partof for local files if explicitly asked for
+				partof=
+			fi
+			[[ ! ${partof} || -n ${link_to} ]] ||
 				die "specifying --link-to is mandatory with local files when using --part-of"
+
 			to_close=
 			[[ -f ${pr} ]] ||
 				die "Parameter neither an URL, number or file: ${pr}"

--- a/pram.1
+++ b/pram.1
@@ -39,6 +39,16 @@ Add Signed-off-by to commits (the default)
 .TP
 \fB-S\fR, \fB\-\-no\-signoff\fR
 Disable adding Signed-off-by to commits
+.TP
+\fB\-p\fR, \fB\-\-part\-of\fR
+Add Part-of to commits, linking to the PR (the default)
+.TP
+\fB-P\fR, \fB\-\-no\-part\-of\fR
+Disable adding Part-of to commits
+.TP
+\fB\-\-link\-to \fIPULL_REQUEST\fR
+Override the pull request the merge is linked to. This will override the
+Part-of trailer, as well as the final Closes trailer.
 
 .SH PARAMETERS
 .IP \fI<pr-number>\fP

--- a/pram.1
+++ b/pram.1
@@ -57,7 +57,7 @@ files.
 The following options are currently supported:
 .TP
 string options:
-\fIpram.editor\fR, \fIpram.repository\fR
+\fIpram.editor\fR, \fIpram.repo\fR
 .TP
 boolean options (\fB--type bool\fR):
 \fIpram.gpgsign\fR, \fIpram.interactive\fR, \fIpram.signoff\fR

--- a/test/01signoff-missing.sh
+++ b/test/01signoff-missing.sh
@@ -43,7 +43,7 @@ cat > trivial.patch <<-EOF
 	2.21.0
 EOF
 
-! bash "${INITDIR}"/../pram --no-gitconfig -e true -G -I -s ./trivial.patch 2> out.txt
+! bash "${INITDIR}"/../pram --no-gitconfig -e true -G -I -s --link-to 123 ./trivial.patch 2> out.txt
 
 diff -u - out.txt <<-EOF
 	Commit no. 0001 was not signed off by the author!

--- a/test/01signoff-partial.sh
+++ b/test/01signoff-partial.sh
@@ -1,0 +1,91 @@
+#!/bin/sh
+# Test whether a set of commits where only one is missing causes rejection.
+
+set -e -x
+
+. ./common-setup.sh
+
+cat > three-commits.patch <<-EOF
+	From 243f5779c2ae9b0d117829b60fe7dbc466e968c0 Mon Sep 17 00:00:00 2001
+	From: Other person <other@example.com>
+	Date: Sat, 1 Jan 2000 00:00:00 +0000
+	Subject: [PATCH 1/3] First patch
+
+	Signed-off-by: Other person <other@example.com>
+
+	---
+	 data.txt | 2 +-
+	 1 file changed, 1 insertion(+), 1 deletion(-)
+
+	diff --git a/data.txt b/data.txt
+	index 5baade6..a9a301d 100644
+	--- a/data.txt
+	+++ b/data.txt
+	@@ -1,6 +1,6 @@
+	 This is some initial data.
+
+	-001100
+	+001101
+	 010010
+	 011110
+	 100001
+	--
+	2.49.0
+
+	From 7aab19414dd17546985fd7c0091e779944e8f0df Mon Sep 17 00:00:00 2001
+	From: Other person <other@example.com>
+	Date: Sat, 1 Jan 2000 00:00:00 +0000
+	Subject: [PATCH 2/3] Second patch
+
+	---
+	 data.txt | 2 +-
+	 1 file changed, 1 insertion(+), 1 deletion(-)
+
+	diff --git a/data.txt b/data.txt
+	index a9a301d..237b5ef 100644
+	--- a/data.txt
+	+++ b/data.txt
+	@@ -1,7 +1,7 @@
+	 This is some initial data.
+
+	 001101
+	-010010
+	+010011
+	 011110
+	 100001
+	 101101
+	--
+	2.49.0
+
+	From 8be43d8aa258fd2c2cf25ec540d19ab6a25d4038 Mon Sep 17 00:00:00 2001
+	From: Other person <other@example.com>
+	Date: Sat, 1 Jan 2000 00:00:00 +0000
+	Subject: [PATCH 3/3] Third patch
+
+	Signed-off-by: Other person <other@example.com>
+
+	---
+	 data.txt | 2 +-
+	 1 file changed, 1 insertion(+), 1 deletion(-)
+
+	diff --git a/data.txt b/data.txt
+	index 237b5ef..6ba7c31 100644
+	--- a/data.txt
+	+++ b/data.txt
+	@@ -3,6 +3,6 @@ This is some initial data.
+	 001101
+	 010011
+	 011110
+	-100001
+	+101101
+	 101101
+	 110011
+	--
+	2.49.0
+EOF
+
+! bash "${INITDIR}"/../pram --no-gitconfig -e true -G -I -s ./three-commits.patch 2> out.txt
+
+diff -u - out.txt <<-EOF
+	Commit no. 0002 was not signed off by the author!
+EOF

--- a/test/01signoff-present.sh
+++ b/test/01signoff-present.sh
@@ -45,7 +45,7 @@ cat > trivial.patch <<-EOF
 	2.21.0
 EOF
 
-bash "${INITDIR}"/../pram --no-gitconfig -e true -G -I -s ./trivial.patch
+bash "${INITDIR}"/../pram --no-gitconfig -e true -G -I -s -P ./trivial.patch
 
 git log --format='%ae%n%an%n%ce%n%cn%n%aI%n%B' -1 > git-log.txt
 diff -u - git-log.txt <<-EOF

--- a/test/02bug-number.sh
+++ b/test/02bug-number.sh
@@ -43,7 +43,7 @@ cat > trivial.patch <<-EOF
 	2.21.0
 EOF
 
-bash "${INITDIR}"/../pram --no-gitconfig -e true -G -I -S -b 314152 ./trivial.patch
+bash "${INITDIR}"/../pram --no-gitconfig -e true -G -I -S -b 314152 -P ./trivial.patch
 
 git log --format='%ae%n%an%n%aI%n%B' -1 > git-log.txt
 diff -u - git-log.txt <<-EOF

--- a/test/02bug-url.sh
+++ b/test/02bug-url.sh
@@ -43,7 +43,7 @@ cat > trivial.patch <<-EOF
 	2.21.0
 EOF
 
-bash "${INITDIR}"/../pram --no-gitconfig -e true -G -I -S -b https://bugs.example.com/123456 ./trivial.patch
+bash "${INITDIR}"/../pram --no-gitconfig -e true -G -I -S -b https://bugs.example.com/123456 -P ./trivial.patch
 
 git log --format='%ae%n%an%n%aI%n%B' -1 > git-log.txt
 diff -u - git-log.txt <<-EOF

--- a/test/02closes-number.sh
+++ b/test/02closes-number.sh
@@ -43,7 +43,7 @@ cat > trivial.patch <<-EOF
 	2.21.0
 EOF
 
-bash "${INITDIR}"/../pram --no-gitconfig -e true -G -I -S -c 314152 ./trivial.patch
+bash "${INITDIR}"/../pram --no-gitconfig -e true -G -I -S -c 314152 -P ./trivial.patch
 
 git log --format='%ae%n%an%n%aI%n%B' -1 > git-log.txt
 diff -u - git-log.txt <<-EOF

--- a/test/02closes-url.sh
+++ b/test/02closes-url.sh
@@ -43,7 +43,7 @@ cat > trivial.patch <<-EOF
 	2.21.0
 EOF
 
-bash "${INITDIR}"/../pram --no-gitconfig -e true -G -I -S -c https://bugs.example.com/123456 ./trivial.patch
+bash "${INITDIR}"/../pram --no-gitconfig -e true -G -I -S -c https://bugs.example.com/123456 -P ./trivial.patch
 
 git log --format='%ae%n%an%n%aI%n%B' -1 > git-log.txt
 diff -u - git-log.txt <<-EOF

--- a/test/03bug-multiple.sh
+++ b/test/03bug-multiple.sh
@@ -43,7 +43,7 @@ cat > trivial.patch <<-EOF
 	2.21.0
 EOF
 
-bash "${INITDIR}"/../pram --no-gitconfig -e true -G -I -S -b 314152 -b 314156 -b 314154 ./trivial.patch
+bash "${INITDIR}"/../pram --no-gitconfig -e true -G -I -S -b 314152 -b 314156 -b 314154 -P ./trivial.patch
 
 git log --format='%ae%n%an%n%aI%n%B' -1 > git-log.txt
 diff -u - git-log.txt <<-EOF

--- a/test/03closes-multiple.sh
+++ b/test/03closes-multiple.sh
@@ -43,7 +43,7 @@ cat > trivial.patch <<-EOF
 	2.21.0
 EOF
 
-bash "${INITDIR}"/../pram --no-gitconfig -e true -G -I -S -c 314152 -c 314156 -c 314154 ./trivial.patch
+bash "${INITDIR}"/../pram --no-gitconfig -e true -G -I -S -c 314152 -c 314156 -c 314154 -P ./trivial.patch
 
 git log --format='%ae%n%an%n%aI%n%B' -1 > git-log.txt
 diff -u - git-log.txt <<-EOF

--- a/test/03combined-bug-closes.sh
+++ b/test/03combined-bug-closes.sh
@@ -43,7 +43,7 @@ cat > trivial.patch <<-EOF
 	2.21.0
 EOF
 
-bash "${INITDIR}"/../pram --no-gitconfig -e true -G -I -S -c 314152 -b 314156 -b 314154 ./trivial.patch
+bash "${INITDIR}"/../pram --no-gitconfig -e true -G -I -S -c 314152 -b 314156 -b 314154 -P ./trivial.patch
 
 git log --format='%ae%n%an%n%aI%n%B' -1 > git-log.txt
 diff -u - git-log.txt <<-EOF

--- a/test/03combined-signoff-bug.sh
+++ b/test/03combined-signoff-bug.sh
@@ -44,7 +44,7 @@ cat > trivial.patch <<-EOF
 	2.21.0
 EOF
 
-bash "${INITDIR}"/../pram --no-gitconfig -e true -G -I -s -b 314152 -c 314154 ./trivial.patch
+bash "${INITDIR}"/../pram --no-gitconfig -e true -G -I -s -b 314152 -c 314154 -P ./trivial.patch
 
 git log --format='%ae%n%an%n%ce%n%cn%n%aI%n%B' -1 > git-log.txt
 diff -u - git-log.txt <<-EOF

--- a/test/04interactive-no.sh
+++ b/test/04interactive-no.sh
@@ -44,6 +44,6 @@ cat > trivial.patch <<-EOF
 EOF
 
 BEFORE=$(git rev-parse HEAD)
-echo 'n' | bash "${INITDIR}"/../pram --no-gitconfig -e true -G -S ./trivial.patch
+echo 'n' | bash "${INITDIR}"/../pram --no-gitconfig -e true -G -S -P ./trivial.patch
 
 [ "${BEFORE}" = "$(git rev-parse HEAD)" ]

--- a/test/04interactive-yes.sh
+++ b/test/04interactive-yes.sh
@@ -43,7 +43,7 @@ cat > trivial.patch <<-EOF
 	2.21.0
 EOF
 
-echo 'y' | bash "${INITDIR}"/../pram --no-gitconfig -e true -G -S ./trivial.patch
+echo 'y' | bash "${INITDIR}"/../pram --no-gitconfig -e true -G -S -P ./trivial.patch
 
 git log --format='%ae%n%an%n%aI%n%B' -1 > git-log.txt
 diff -u - git-log.txt <<-EOF

--- a/test/05editor-empty.sh
+++ b/test/05editor-empty.sh
@@ -44,6 +44,6 @@ cat > trivial.patch <<-EOF
 EOF
 
 BEFORE=$(git rev-parse HEAD)
-bash "${INITDIR}"/../pram --no-gitconfig -e 'truncate -s 0' -G -I -S ./trivial.patch
+bash "${INITDIR}"/../pram --no-gitconfig -e 'truncate -s 0' -G -I -S -P ./trivial.patch
 
 [ "${BEFORE}" = "$(git rev-parse HEAD)" ]

--- a/test/06gpgsign.sh
+++ b/test/06gpgsign.sh
@@ -49,7 +49,7 @@ cat > trivial.patch <<-EOF
 	2.21.0
 EOF
 
-bash "${INITDIR}"/../pram --no-gitconfig -e true -I -S ./trivial.patch
+bash "${INITDIR}"/../pram --no-gitconfig -e true -I -S -P ./trivial.patch
 
 git log --format='%ae%n%an%n%aI%n%G?%n%B' -1 > git-log.txt
 diff -u - git-log.txt <<-EOF

--- a/test/10threeway.sh
+++ b/test/10threeway.sh
@@ -47,7 +47,7 @@ cat > trivial.patch <<-EOF
 	2.21.0
 EOF
 
-bash "${INITDIR}"/../pram --no-gitconfig -e true -G -I -S ./trivial.patch
+bash "${INITDIR}"/../pram --no-gitconfig -e true -G -I -S -P ./trivial.patch
 
 git log --format='%ae%n%an%n%aI%n%B' -1 > git-log.txt
 diff -u - git-log.txt <<-EOF

--- a/test/11combined-partof-signoff-bug.sh
+++ b/test/11combined-partof-signoff-bug.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
-# Test whether applying a plain patch via pram works.
+# Test whether Part-of is properly combined with signoff and bug/closes tags.
+# Minor variation on 03combined-signoff-bug.
 
 set -e -x
 
@@ -7,10 +8,11 @@ set -e -x
 
 cat > trivial.patch <<-EOF
 	From 88460bc61f56546da478dc6fd4682e7c62cc6c80 Mon Sep 17 00:00:00 2001
-	From: PRam test <pram@example.com>
+	From: Other person <other@example.com>
 	Date: Sat, 1 Jan 2000 00:00:00 +0000
 	Subject: [PATCH] A trivial patch
 
+	Signed-off-by: Other person <other@example.com>
 	---
 	 data.txt    | 4 ++--
 	 newfile.txt | 1 +
@@ -38,25 +40,31 @@ cat > trivial.patch <<-EOF
 	--- /dev/null
 	+++ b/newfile.txt
 	@@ -0,0 +1 @@
-	+Also, a new file with CRLF line ending.
+	+Also, a new file.
 	--
 	2.21.0
 EOF
 
-bash "${INITDIR}"/../pram --no-gitconfig -e true -G -I -S --link-to 123 ./trivial.patch
+bash "${INITDIR}"/../pram --no-gitconfig -e true -G -I -s -b 314152 -c 314154 --link-to 123 ./trivial.patch
 
-git log --format='%ae%n%an%n%aI%n%B' -1 > git-log.txt
+git log --format='%ae%n%an%n%ce%n%cn%n%aI%n%B' -1 > git-log.txt
 diff -u - git-log.txt <<-EOF
+	other@example.com
+	Other person
 	pram@example.com
 	PRam test
 	2000-01-01T00:00:00Z
 	A trivial patch
 
+	Signed-off-by: Other person <other@example.com>
 	Part-of: https://github.com/gentoo/gentoo/pull/123
+	Bug: https://bugs.gentoo.org/314152
+	Closes: https://bugs.gentoo.org/314154
 	Closes: https://github.com/gentoo/gentoo/pull/123
+	Signed-off-by: PRam test <pram@example.com>
 
 EOF
 sha1sum -c <<EOF
 8054584c7b1fa9b5bdd7ee1177e78c99ea2cce04  data.txt
-f83370dac2432114808711e29f399f9b0c87fc23  newfile.txt
+810ded956f70861874e2c6083c5dc9e9e80f1808  newfile.txt
 EOF


### PR DESCRIPTION
This is https://github.com/projg2/pram/pull/9 revived and tweaked a little.

Most of the review feedback should be addressed, and along with it, things should be optimized a little more. The most notable change (both in terms of simplified code and in terms of behavior) is that `linked_pr` is gone, replaced by `to_close`, per one of the review comments. This has the effect of adding `Closes:` trailers in some new places, which I think is generally desirable, as it allows you to close a pull request while applying it as a patch file or from an unrelated URL.

Following on from that, `--part-of-pr` has been renamed to `--link-to`. I've also dropped the `-p` implication here, as it might be useful for overriding the final `Closes:` even if the `Part-of:` trailer is unwanted. I've kept the restriction on only providing one, since I can't see any justification for more than one here (nor do I understand how it would -work-).

All tests are also updated to pass with the new trailer, mostly by disabling it, but a couple pass `--link-to 123`.

This also contains the two miscellaneous fixes that were part of #9, as their own commits before the main commit.

As always, feedback is appreciated :)