### PR TITLE
Better handling for GitHub branch/commit diff URLs

### DIFF
--- a/pram
+++ b/pram
@@ -244,6 +244,13 @@ main() {
 			to_close=${pr%.patch}
 			pr=${to_close}.patch
 			;;
+		*://github.com/*/*/compare/*)
+			# GitHub branch/commit diff
+			if [[ "${pr}" != *.patch ]]; then
+				pr=${pr}.patch
+			fi
+			to_close=
+			;;
 		*://*.bugs.gentoo.org/attachment.cgi?*)
 			# Gentoo Bugzilla attachment
 			# (get bug no from domain name)

--- a/pram
+++ b/pram
@@ -268,14 +268,6 @@ main() {
 			;;
 		*)
 			# a local file maybe?
-			if [[ -z ${link_to} ]]; then
-				# only add partof for local files if explicitly asked for
-				if [[ ${partof} == def ]]; then
-					partof=
-				elif [[ ${partof} ]]; then
-					die "specifying --link-to is mandatory with local files when using --part-of"
-				fi
-			fi
 			to_close=
 			[[ -f ${pr} ]] ||
 				die "Parameter neither an URL, number or file: ${pr}"
@@ -283,6 +275,16 @@ main() {
 			pr=
 			;;
 	esac
+
+	if [[ -z ${to_close} && -z ${link_to} ]]; then
+		# only add partof for local files and arbitrary URLs if explicitly asked for
+		if [[ ${partof} == def ]]; then
+			partof=
+		elif [[ ${partof} ]]; then
+			die "could not determine a PR from supplied patch, please specify with --link-to"
+		fi
+	fi
+
 	if [[ -n ${pr} ]]; then
 		wget -O "${tempdir}/all.patch" "${pr}" || die "Fetching patch failed"
 	fi


### PR DESCRIPTION
This should address both of Sam's points in #12.

Moves the check for a blank `to_close` outside of the switch statement, and handles a blank `to_close` regardless of why it ended up blank, fixing issues with arbitrary URLs. Also adds explicit support for "compare" URLs, so you don't have to add `.patch` manually.