### PR TITLE
Deduplicate signed-off-by trailers

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -14,6 +14,7 @@ tests = [
   '01signoff-missing',
   '01signoff-partial',
   '01signoff-present',
+  '01signoff-multiple',
   '02bug-number',
   '02bug-url',
   '02closes-number',
@@ -31,6 +32,7 @@ tests = [
   '10threeway-disabled',
   '11combined-partof-signoff-bug',
   '11partof',
+  '12signoff-dedup',
 ]
 
 foreach t : tests

--- a/pram
+++ b/pram
@@ -57,15 +57,6 @@ print_help() {
 	echo "  boolean options: pram.gpgsign, pram.interactive, pram.signoff, pram.partof"
 }
 
-# add_trailer <file> <line-to-add>
-add_trailer() {
-	local file=${1}
-	local line=${2}
-
-	sed -i -e "1,/^---$/s@^---\$@${line}\n\0@" "${file}" ||
-		die "Appending trailer via sed failed"
-}
-
 main() {
 	# make sure files are sorted ascending
 	local -x LC_COLLATE=C
@@ -374,7 +365,7 @@ main() {
 	fi
 
 	local patches=( "${tempdir}"/[0-9]* )
-	if [[ ${signoff} || ${partof} ]]; then
+	if [[ ${signoff} ]]; then
 		local f
 		for f in "${patches[@]}"; do
 			if [[ ${signoff} ]]; then
@@ -382,32 +373,49 @@ main() {
 					die "Commit no. ${f##*/} was not signed off by the author!"
 				fi
 			fi
-
-			if [[ ${partof} ]]; then
-				add_trailer "${f}" "Part-of: ${to_close}"
-			fi
 		done
 	fi
-
+	if [[ ${partof} ]]; then
+		local partof_conf=(
+			-c trailer.partof.key="Part-of: "
+			-c trailer.partof.ifmissing=add
+		)
+		git "${partof_conf[@]}" interpret-trailers --in-place --trailer="partof: ${to_close}" "${patches[@]}" ||
+			die "git interpret-trailers failed"
+	fi
+	local git_conf=(
+		-c trailer.bug.key="Bug: "
+		-c trailer.bug.ifexists=addIfDifferent
+		-c trailer.closes.key="Closes: "
+		-c trailer.closes.ifexists=addIfDifferent
+		-c trailer.merges.key="Merges: "
+		-c trailer.merges.ifexists=addIfDifferent
+	)
+	local git_trailers=()
 	# append bug references
 	local b
 	for b in "${bug[@]}"; do
 		[[ ${b} != *://* ]] && b=https://bugs.gentoo.org/${b}
-		add_trailer "${patches[-1]}" "Bug: ${b}"
+		git_trailers+=( --trailer="bug: ${b}" )
 	done
 	for b in "${closes[@]}"; do
 		[[ ${b} != *://* ]] && b=https://bugs.gentoo.org/${b}
-		add_trailer "${patches[-1]}" "Closes: ${b}"
+		git_trailers+=( --trailer="closes: ${b}" )
 	done
 	# append Closes: (or Merges:) to the final commit if missing
 	if [[ -n ${to_close} ]]; then
-		local trailer=Closes
-		[[ ${merge} == 1 ]] && trailer=Merges
-
-		if ! grep -q "^${trailer}: ${to_close}" "${patches[-1]}"; then
-			add_trailer "${patches[-1]}" "${trailer}: ${to_close}"
-		fi
+		local trailer=closes
+		[[ ${merge} == 1 ]] && trailer=merges
+		git_trailers+=( --trailer="${trailer}: ${to_close}" )
 	fi
+
+	# Add Bug: and Closes/Merges: tags to the last patch
+	if [[ "${#git_trailers[@]}" -gt 0 ]]; then
+		git "${git_conf[@]}" interpret-trailers --in-place \
+			"${git_trailers[@]}" "${patches[-1]}" ||
+				die "git interpret-trailers failed"
+	fi
+
 	# Append committer signed-off-by (only if missing)
 	if [[ -n ${signoff} ]]; then
 		local username="$(git config user.name)"

--- a/pram
+++ b/pram
@@ -408,6 +408,20 @@ main() {
 			add_trailer "${patches[-1]}" "${trailer}: ${to_close}"
 		fi
 	fi
+	# Append committer signed-off-by (only if missing)
+	if [[ -n ${signoff} ]]; then
+		local username="$(git config user.name)"
+		local useremail="$(git config user.email)"
+		local my_gitconf=(
+			-c trailer.sign.key="Signed-off-by: "
+			-c trailer.sign.ifmissing=add
+			-c trailer.sign.ifexists=addIfDifferent
+		)
+
+		git "${my_gitconf[@]}" interpret-trailers --in-place \
+			--trailer="sign: $username <$useremail>" "${patches[@]}" ||
+				die "Adding Signed-off-by trailers failed"
+	fi
 
 	# concatenate the patches back
 	cat "${patches[@]}" > "${tempdir}/all.patch" ||
@@ -438,7 +452,7 @@ main() {
 			esac
 		done
 	fi
-	git am --keep-cr -3 ${signoff:+-s} ${gpgsign:+-S} "${am_options[@]}" \
+	git am --keep-cr -3 ${gpgsign:+-S} "${am_options[@]}" \
 			"${tempdir}/all.patch" || die "git am failed"
 }
 

--- a/test/01signoff-multiple.sh
+++ b/test/01signoff-multiple.sh
@@ -1,0 +1,123 @@
+#!/bin/sh
+# Test whether multiple commits are signed-off properly. One of them
+# already has the trailer, so it shouldn't be duplicated.
+
+set -e -x
+
+. ./common-setup.sh
+
+cat > three-commits.patch <<-EOF
+	From 243f5779c2ae9b0d117829b60fe7dbc466e968c0 Mon Sep 17 00:00:00 2001
+	From: Other person <other@example.com>
+	Date: Sat, 1 Jan 2000 00:00:00 +0000
+	Subject: [PATCH 1/3] First patch
+
+	Signed-off-by: Other person <other@example.com>
+
+	---
+	 data.txt | 2 +-
+	 1 file changed, 1 insertion(+), 1 deletion(-)
+
+	diff --git a/data.txt b/data.txt
+	index 5baade6..a9a301d 100644
+	--- a/data.txt
+	+++ b/data.txt
+	@@ -1,6 +1,6 @@
+	 This is some initial data.
+
+	-001100
+	+001101
+	 010010
+	 011110
+	 100001
+	--
+	2.49.0
+
+	From 7aab19414dd17546985fd7c0091e779944e8f0df Mon Sep 17 00:00:00 2001
+	From: Other person <other@example.com>
+	Date: Sat, 1 Jan 2000 00:00:00 +0000
+	Subject: [PATCH 2/3] Second patch
+
+	Signed-off-by: Other person <other@example.com>
+	Signed-off-by: PRam test <pram@example.com>
+
+	---
+	 data.txt | 2 +-
+	 1 file changed, 1 insertion(+), 1 deletion(-)
+
+	diff --git a/data.txt b/data.txt
+	index a9a301d..237b5ef 100644
+	--- a/data.txt
+	+++ b/data.txt
+	@@ -1,7 +1,7 @@
+	 This is some initial data.
+
+	 001101
+	-010010
+	+010011
+	 011110
+	 100001
+	 101101
+	--
+	2.49.0
+
+	From 8be43d8aa258fd2c2cf25ec540d19ab6a25d4038 Mon Sep 17 00:00:00 2001
+	From: Other person <other@example.com>
+	Date: Sat, 1 Jan 2000 00:00:00 +0000
+	Subject: [PATCH 3/3] Third patch
+
+	Signed-off-by: Other person <other@example.com>
+
+	---
+	 data.txt | 2 +-
+	 1 file changed, 1 insertion(+), 1 deletion(-)
+
+	diff --git a/data.txt b/data.txt
+	index 237b5ef..6ba7c31 100644
+	--- a/data.txt
+	+++ b/data.txt
+	@@ -3,6 +3,6 @@ This is some initial data.
+	 001101
+	 010011
+	 011110
+	-100001
+	+101101
+	 101101
+	 110011
+	--
+	2.49.0
+EOF
+
+bash "${INITDIR}"/../pram --no-gitconfig -e true -G -I -s -P ./three-commits.patch
+
+git log --format='%ae%n%an%n%aI%n%B' -3 > git-log.txt
+diff -u - git-log.txt <<-EOF
+	other@example.com
+	Other person
+	2000-01-01T00:00:00Z
+	Third patch
+
+	Signed-off-by: Other person <other@example.com>
+	Signed-off-by: PRam test <pram@example.com>
+
+	other@example.com
+	Other person
+	2000-01-01T00:00:00Z
+	Second patch
+
+	Signed-off-by: Other person <other@example.com>
+	Signed-off-by: PRam test <pram@example.com>
+
+	other@example.com
+	Other person
+	2000-01-01T00:00:00Z
+	First patch
+
+	Signed-off-by: Other person <other@example.com>
+	Signed-off-by: PRam test <pram@example.com>
+
+EOF
+
+sha1sum -c <<EOF
+1d0dac1918223c41f4d08973e460bf82508a19ba  data.txt
+EOF

--- a/test/01signoff-multiple.sh
+++ b/test/01signoff-multiple.sh
@@ -88,7 +88,7 @@ cat > three-commits.patch <<-EOF
 	2.49.0
 EOF
 
-bash "${INITDIR}"/../pram --no-gitconfig -e true -G -I -s -P ./three-commits.patch
+bash "${INITDIR}"/../pram --no-gitconfig -e true -G -I -s -b 314152 -b 314156 -c 314154 --link-to https://codeberg.org/gentoo/gentoo/pull/123 ./three-commits.patch
 
 git log --format='%ae%n%an%n%aI%n%B' -3 > git-log.txt
 diff -u - git-log.txt <<-EOF
@@ -98,6 +98,11 @@ diff -u - git-log.txt <<-EOF
 	Third patch
 
 	Signed-off-by: Other person <other@example.com>
+	Part-of: https://codeberg.org/gentoo/gentoo/pull/123
+	Bug: https://bugs.gentoo.org/314152
+	Bug: https://bugs.gentoo.org/314156
+	Closes: https://bugs.gentoo.org/314154
+	Closes: https://codeberg.org/gentoo/gentoo/pull/123
 	Signed-off-by: PRam test <pram@example.com>
 
 	other@example.com
@@ -107,6 +112,7 @@ diff -u - git-log.txt <<-EOF
 
 	Signed-off-by: Other person <other@example.com>
 	Signed-off-by: PRam test <pram@example.com>
+	Part-of: https://codeberg.org/gentoo/gentoo/pull/123
 
 	other@example.com
 	Other person
@@ -114,6 +120,7 @@ diff -u - git-log.txt <<-EOF
 	First patch
 
 	Signed-off-by: Other person <other@example.com>
+	Part-of: https://codeberg.org/gentoo/gentoo/pull/123
 	Signed-off-by: PRam test <pram@example.com>
 
 EOF

--- a/test/12signoff-dedup.sh
+++ b/test/12signoff-dedup.sh
@@ -1,0 +1,67 @@
+#!/bin/sh
+# Test that signed-off-by trailers are not duplicated. The patch
+# already has the line that pram will add, so it shouldn't add another
+# one.
+
+set -e -x
+
+. ./common-setup.sh
+
+cat > trivial.patch <<-EOF
+	From 88460bc61f56546da478dc6fd4682e7c62cc6c80 Mon Sep 17 00:00:00 2001
+	From: PRam test <pram@example.com>
+	Date: Sat, 1 Jan 2000 00:00:00 +0000
+	Subject: [PATCH] A trivial patch
+
+	Signed-off-by: PRam test <pram@example.com>
+	---
+	 data.txt    | 4 ++--
+	 newfile.txt | 1 +
+	 2 files changed, 3 insertions(+), 2 deletions(-)
+	 create mode 100644 newfile.txt
+
+	diff --git a/data.txt b/data.txt
+	index 5baade6..0139962 100644
+	--- a/data.txt
+	+++ b/data.txt
+	@@ -1,8 +1,8 @@
+	 This is some initial data.
+
+	 001100
+	-010010
+	-011110
+	 100001
+	+011110
+	+010010
+	 101101
+	 110011
+	diff --git a/newfile.txt b/newfile.txt
+	new file mode 100644
+	index 0000000..6d8bf33
+	--- /dev/null
+	+++ b/newfile.txt
+	@@ -0,0 +1 @@
+	+Also, a new file with CRLF line ending.
+	--
+	2.21.0
+EOF
+
+bash "${INITDIR}"/../pram --no-gitconfig -e true -s -G -I --link-to 123 ./trivial.patch
+
+git log --format='%ae%n%an%n%aI%n%B' -1 > git-log.txt
+diff -u - git-log.txt <<-EOF
+	pram@example.com
+	PRam test
+	2000-01-01T00:00:00Z
+	A trivial patch
+
+	Signed-off-by: PRam test <pram@example.com>
+	Part-of: https://github.com/gentoo/gentoo/pull/123
+	Closes: https://github.com/gentoo/gentoo/pull/123
+
+EOF
+
+sha1sum -c <<EOF
+8054584c7b1fa9b5bdd7ee1177e78c99ea2cce04  data.txt
+3f6e6d8b9efc370f5cb1bf6273b1ca1eeee958e0  newfile.txt
+EOF


### PR DESCRIPTION
Using git-interpret-trailers(1) we can parse out the trailers of each patch and see if a Signed-off-by trailer is needed (of course, only if we're supposed to do signoff).

Closes: https://github.com/gentoo/pram/issues/6